### PR TITLE
Add --cmd, --no-ext and --add-ext options

### DIFF
--- a/mumu.pl
+++ b/mumu.pl
@@ -2,7 +2,7 @@
 #
 # mumu.pl  -  Implementation of the Multi-Multi-FASTA/Q file format
 #
-# Version 0.3.0 (September 30, 2020)
+# Version 0.4.0 (October 8, 2020)
 #
 # By Kirill Kryukov
 #
@@ -12,19 +12,22 @@
 #
 
 use strict;
-use File::Basename qw(dirname);
+use File::Basename qw(basename dirname);
 use File::Glob qw(:bsd_glob);
 use File::Path qw(make_path);
 use Getopt::Long qw(:config pass_through);
 
 my ($dir) = ('.');
-my ($format, $stdin, $unpack, $overwrite, $tag_all, $separator, $help, $version);
+my ($format, $stdin, $unpack, $no_ext, $add_ext, $command_template, $overwrite, $tag_all, $separator, $help, $version);
 GetOptions(
     'dir=s'   => \$dir,
     'fasta'   => sub { $format = 'fasta'; },
     'fastq'   => sub { $format = 'fastq'; },
     'stdin'   => \$stdin,
     'unpack'  => \$unpack,
+    'no-ext'  => \$no_ext,
+    'add-ext=s' => \$add_ext,
+    'cmd=s'     => \$command_template,
     'overwrite' => \$overwrite,
     'sep'     => \$separator,
     'all'     => \$tag_all,
@@ -34,7 +37,7 @@ GetOptions(
 
 if ($version)
 {
-    print q`Multi-Multi-FASTA/Q codec, version 0.3.0, 2020-09-30
+    print q`Multi-Multi-FASTA/Q codec, version 0.4.0, 2020-10-08
 by Kirill Kryukov, https://github.com/KirillKryukov/mumu
 `;
     exit;
@@ -48,11 +51,14 @@ Unpacking:
     mumu.pl --unpack [OPTIONS] <packed.fa
 Options:
   --dir DIR   - Enter DIR before packing or unpacking
+  --cmd CMD   - Run CMD on each file (may include {FILE}, {PATH}, {FILE-NO-EXT}, {PATH-NO-EXT})
   --sep 'STR' - Use STR as separator (default: '>' for fasta, '@' for fastq)
   --all       - Tag all sequences with filename
   --fasta     - Process FASTA-formatted data (default)
   --fastq     - Process FASTQ-formatted data
   --stdin     - Read list of files to pack from standard input
+  --no-ext    - Don't store file extensions when packing
+  --add-ext EXT - Add extension EXT to each processed filename
   --overwrite - Overwrite existing files when unpacking
   --help      - Print this help and exit
   --version   - Print version and exit
@@ -64,6 +70,11 @@ Options:
 if (!defined $format) { $format = 'fasta'; }
 if (!defined $separator) { $separator = ($format eq 'fasta') ? '>' : '@'; }
 my $fastq = ($format eq 'fastq');
+
+if (defined $command_template and $command_template !~ /\{(FILE|PATH|FILE-NO-EXT|PATH-NO-EXT)\}/)
+{
+    die "--cmd must include either {FILE}, {PATH}, {FILE-NO-EXT}, or {PATH-NO-EXT}\n";
+}
 
 
 my %file_seen;
@@ -105,29 +116,55 @@ sub mumu_unpack
                 $path =~ s/[\x0D\x0A]+$//;
                 $path =~ s/^([a-zA-Z]:|[\/\\]|\.\.[\/\\])+//;
                 $path =~ s/([\/\\])\.\.[\/\\]/$1/g;
+                if ($no_ext) { $path =~ s/\.[^\.\/\\]*$//; }
+                if (defined $add_ext) { $path .= $add_ext; }
+
                 if ($path ne $prev_path)
                 {
-                    if ($file_seen{$path})
+                    if ($path =~ /[\/\\]/)
                     {
-                        open($OUT, '>>', $path) or die "Can't append to file \"$path\"\n";
-                        binmode $OUT;
+                        my $d = dirname($path);
+                        make_path($d);
+                        if (!-e $d or !-d $d) { die "Can't create directory \"$d\"\n"; }
                     }
-                    else
+
+                    if (defined $command_template)
                     {
-                        if ($path =~ /[\/\\]/)
+                        if (!exists($file_seen{$path}) or !-e $path or $overwrite)
                         {
-                            my $d = dirname($path);
-                            make_path($d);
-                            if (!-e $d or !-d $d) { die "Can't create directory \"$d\"\n"; }
-                        }
-                        if (!-e $path or $overwrite)
-                        {
-                            open($OUT, '>', $path) or die "Can't create file \"$path\"\n";
-                            binmode $OUT;
+                            my ($base, $path_no_ext, $base_no_ext) = parse_path($path);
+                            my $cmd = $command_template;
+                            $cmd =~ s/\{PATH\}/$path/g;
+                            $cmd =~ s/\{FILE\}/$base/g;
+                            $cmd =~ s/\{PATH-NO-EXT\}/$path_no_ext/g;
+                            $cmd =~ s/\{FILE-NO-EXT\}/$base_no_ext/g;
+                            open($OUT, '|-', $cmd) or die "Can't run \"$cmd\"\n";
                             $file_seen{$path} = 1;
                         }
                         else { undef $OUT; }
                     }
+                    else
+                    {
+                        my $actual_path = $path;
+                        if ($no_ext) { $actual_path =~ s/\.[^\.\/\\]*$//; }
+                        if (defined $add_ext) { $actual_path .= $add_ext; }
+                        if (exists $file_seen{$path})
+                        {
+                            open($OUT, '>>', $actual_path) or die "Can't append to file \"$actual_path\"\n";
+                            binmode $OUT;
+                        }
+                        else
+                        {
+                            if (!-e $actual_path or $overwrite)
+                            {
+                                open($OUT, '>', $actual_path) or die "Can't create file \"$actual_path\"\n";
+                                binmode $OUT;
+                                $file_seen{$path} = 1;
+                            }
+                            else { undef $OUT; }
+                        }
+                    }
+
                     $prev_path = $path;
                 }
 
@@ -169,7 +206,22 @@ sub mumu_pack
 
     foreach my $file (@files)
     {
-        open (my $IN, '<', $file) or die "Can't open \"$file\"\n";
+        my $IN;
+        if (defined $command_template)
+        {
+            my $path = $file;
+            my ($base, $path_no_ext, $base_no_ext) = parse_path($path);
+            my $cmd = $command_template;
+            $cmd =~ s/\{PATH\}/$path/g;
+            $cmd =~ s/\{FILE\}/$base/g;
+            $cmd =~ s/\{PATH-NO-EXT\}/$path_no_ext/g;
+            $cmd =~ s/\{FILE-NO-EXT\}/$base_no_ext/g;
+            open($IN, '-|', $cmd) or die "Can't run \"$cmd\"\n";
+        }
+        else
+        {
+            open($IN, '<', $file) or die "Can't open \"$file\"\n";
+        }
         binmode $IN;
 
         if ($tag_all)
@@ -182,7 +234,7 @@ sub mumu_pack
                     if ($part_num == 0)
                     {
                         s/[\x0D\x0A]+$//;
-                        print $_, $separator, $file, "\n";
+                        print $_, $separator, prepare_file_path_to_store($file), "\n";
                         next;
                     }
                     print $_;
@@ -196,7 +248,7 @@ sub mumu_pack
                     if (substr($_, 0, 1) eq '>')
                     {
                         s/[\x0D\x0A]+$//;
-                        print $_, $separator, $file, "\n";
+                        print $_, $separator, prepare_file_path_to_store($file), "\n";
                         next;
                     }
                     print $_;
@@ -207,7 +259,7 @@ sub mumu_pack
         {
             my $first_line = <$IN>;
             $first_line =~ s/[\x0D\x0A]+$//;
-            print $first_line, $separator, $file, "\n";
+            print $first_line, $separator, prepare_file_path_to_store($file), "\n";
             while (<$IN>) { print $_; }
         }
 
@@ -231,4 +283,26 @@ sub add_file
     if (exists $file_seen{$file}) { next; }
     $file_seen{$file} = 1;
     push @files, $file;
+}
+
+
+sub parse_path
+{
+    my ($path) = @_;
+    my $path_no_ext = $path;
+    $path_no_ext =~ s/\.[^\.]*$//;
+    my $base = basename($path);
+    my $base_no_ext = $base;
+    $base_no_ext =~ s/\.[^\.]*$//;
+    return ($base, $path_no_ext, $base_no_ext);
+}
+
+
+sub prepare_file_path_to_store
+{
+    my ($path) = @_;
+    if ($no_ext) { $path =~ s/\.[^\.\/\\]*$//; }
+    if (defined $add_ext) { $path .= $add_ext; }
+    $path =~ s/\\/\//g;
+    return $path;
 }


### PR DESCRIPTION
Adds new options: --cmd, --no-ext, --add-ext. This allows specifying a command to process each individual file while it's being packed or unpacked.